### PR TITLE
added query string support

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -58,6 +58,15 @@
             paramNotRequired = req.params.not_required;
         });
 
+        router.get('/query/:routeparam',function(req,e){
+                    equal(req.params.routeparam,'zero');
+                    ok(req.query.zero === undefined);
+                    equal(req.query.param1,'one');
+                    equal(req.query.param2,'two');
+                    equal(req.query.param3,'');
+                    equal(req.query.param4,null);
+        });
+
         router.get('/settings/wildcard/*', function(req, e){
             paramWildcard = req.params[0];
         });
@@ -151,6 +160,10 @@
                 done();
             }, 30);
         });
+        
+        test('Query parameters functions correctly',function(){
+                    router.navigate('/query/zero?param1=one&param2=two&param3=&param4');
+        });
 
         test('Multiple routes can be called', function(){
             router.navigate('/multi');
@@ -171,7 +184,7 @@
             equal(defaultPreventedFnCalled, false);
         });
 
-        test('Router only fires handler once', function(){ 
+        test('Router only fires handler once', function(){
             router.navigate('/once');
             equal(onceTimesRan, 1);
         });


### PR DESCRIPTION
I wanted support for this in my project to make the logic a bit closer to express for example so that there is a req.query object with passed in parameters in the url. I didn't want the order of the parameters to matter for some routes and also including stuff like a token in a route param feels better in a query string. 

I made sure all tests pass and added a new test. (it works side by side with named params). 

Atom removed some trailing spaces automatically idk if you want to keep them.

Also, this is my first pull request ever , hope it was helpful :)
