### PR TITLE
Offer 'silent' option to prevent Grapnel from modifying browser history / window.location

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ require(['lib/grapnel'], function(Grapnel){
 });
 ```
 
+## Silent
+Enable silent mode to prevent Grapnel from modifying browser history and window.location: 
+```javascript
+var router = new Grapnel({ mode : 'silent' });
+```
+
 &nbsp;
 
 ***

--- a/src/grapnel.js
+++ b/src/grapnel.js
@@ -230,6 +230,8 @@
             if (self.options.mode === 'pushState') {
                 frag = (self.options.root) ? (self.options.root + pathname) : pathname;
                 root.history.pushState({}, null, frag);
+            } else if (self.options.mode == 'silent') {
+                frag = (self.options.root) ? (self.options.root + pathname) : pathname;
             } else if (root.location) {
                 root.location.hash = (self.options.hashBang ? '!' : '') + pathname;
             } else {
@@ -239,7 +241,7 @@
             return this;
         } else if ('undefined' === typeof pathname) {
             // Get path
-            if (self.options.mode === 'pushState') {
+            if (self.options.mode === 'pushState' || self.options.mode === 'silent') {
                 frag = root.location.pathname.replace(self.options.root, '');
             } else if (self.options.mode !== 'pushState' && root.location) {
                 frag = (root.location.hash) ? root.location.hash.split((self.options.hashBang ? '#!' : '#'))[1] : '';


### PR DESCRIPTION
For my project I only want Grapnel for the basic routing and so this change does the trick. 
This would also let you add an alternative router to handle pushState or window.location hash changes. 
