### PR TITLE
Allow next() to be called from the last middleware in the stack (server side)

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ Server.prototype.start = function() {
     // Return server middleware to HTTP createServer()
     return function(req, res) {
         // For every inbound request, we want to map node's req and res to middleware
-        Grapnel.CallStack.global = [serverMiddleware(req, res, router)];
+        router.rootStack = [serverMiddleware(req, res, router)];
         // Finally, navigate router
         router.navigate(req.url);
     }

--- a/index.js
+++ b/index.js
@@ -103,9 +103,13 @@ function serverMiddleware(req, res, router) {
         req.event = event;
         // Override next -- this is the same as default event.next() functionality except the arguments are now `req`, `res`, and `next()`
         req.event.next = function() {
-            return event.stack.shift().call(router, req, res, function() {
-                event.next.call(event);
-            });
+            var firstMiddleware = event.stack.shift();
+
+            if (firstMiddleware) {
+                return firstMiddleware.call(router, req, res, function() {
+                    event.next.call(event);
+                });
+            }
         }
 
         next();


### PR DESCRIPTION
Done same thing on the server so that when `next()` is called from the last middleware in the stack it will not throw. If no `res.end()` was specified in the last middleware it will be up to Express to finish the response.

The reason why I needed this feature is because I have many middlewares that are triggering `next()`, but they can be attached to the stack in a messy order (hooked up from different files). Even my very last middleware which prints the HTML to the browser contains `next()`. Which looks like so:

``` js
function(req, res, next) {
  // run all other middlewares (if any) before continuing the current one
  next()

  ...
  res.end('html')
}
```
